### PR TITLE
Add mpileup streaming

### DIFF
--- a/src/readData.h
+++ b/src/readData.h
@@ -475,15 +475,10 @@ void estimateSeqErrorRate(Config<TTreeType> & config,
     std::set<std::tuple<std::string, std::string>> const & errExMap,
     std::vector<unsigned> const & tumorCellPos,
     std::vector<unsigned> const & normalCellPos,
+    std::ifstream & inputStream,
     std::stringstream & inFileHeadBuff)
 {
     //estimate the error rate
-    std::ifstream inputStream(config.inFileName);
-    if (inputStream.fail())
-    {
-        std::cerr << "The pileup file provided does not exist or you lack permission to access it." << std::endl;
-        return;
-    }
     std::string currLine;
     std::vector<std::string> splitVec;
     std::vector<std::array<unsigned, 5>> tumor_counts(tumorCellPos.size(), {{0,0,0,0,0}});
@@ -509,8 +504,7 @@ void estimateSeqErrorRate(Config<TTreeType> & config,
         }
     }
     ++seqErrors; // add pseudo counts
-    inputStream.close();
-    
+
     // set the new estimated error rate
 
     if(seqErrorsCombCov > 0)
@@ -840,14 +834,14 @@ bool readMpileupFile(Config<TTreeType> & config)
 
 
     std::stringstream inFileHeadBuff;
-    if (config.estimateSeqErrorRate)
-    {
-        estimateSeqErrorRate(config, exMap, errExMap, tumorCellPos, normalCellPos, inFileHeadBuff);
-    }
-
     std::ifstream inputStream(config.inFileName, std::ifstream::in);
     if (!inputStream){
         throw std::runtime_error("Could not open input file " + config.inFileName);
+    }
+
+    if (config.estimateSeqErrorRate)
+    {
+        estimateSeqErrorRate(config, exMap, errExMap, tumorCellPos, normalCellPos, inputStream, inFileHeadBuff);
     }
 
     std::string currentChrom = "";

--- a/src/version.h
+++ b/src/version.h
@@ -8,6 +8,6 @@
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 1
 #define VERSION_PATCH 4
-#define VERSION_STRING "dev"
+#define VERSION_STRING "dev-ccf8de7"
 
 #endif //SCIPHI_VERSION_H

--- a/src/version.h
+++ b/src/version.h
@@ -8,6 +8,6 @@
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 1
 #define VERSION_PATCH 4
-#define VERSION_STRING "dev-ccf8de7"
+#define VERSION_STRING "dev-1bce5ac"
 
 #endif //SCIPHI_VERSION_H


### PR DESCRIPTION
sciphi reads the first `config.errorRateEstLoops` (100000 by default) lines of the `.mpileup` file twice: Once in `estimateSeqErrorRate()` and once in `readMpileupFile()`. This is accomplished by opening `config.inFileName` twice.  If the input file `config.inFileName` is a regular file, then this is fine because the `ifstream` constructor seeks to the beginning of the file. However, if `config.inFileName` is a pipe, then the second call to `ifstream` opens where the first file handle left off.  The result is that the first 100,000 lines of the mpileup file are dropped when reading from a pipe.

Whole-genome mpileup files can get very large, and except for the first 100k lines, sciphi streams through the file only once.  With the changes in this PR, sciphi buffers the first 100k lines in memory and reads from them a second time before continuing to read from the primary input file handle.

Now I can sciphi like this in bash 4.4:
```bash
./sciphi -o output --in cell_names.txt --seed 42 <(gzip -dc mpileup.gz)
```

In theory, a samtools mpileup call could also be put inside of the bash subshell.